### PR TITLE
Cleanup show_codes

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -57,7 +57,6 @@ message NextStopTimeRequest {
     optional int32 max_date_times         = 11; // to be removed
     repeated string forbidden_uri         = 12;
     optional string calendar              = 13;
-    optional bool show_codes              = 14; // to be removed
     optional uint64 until_datetime        = 15;
     optional uint64 _current_datetime     = 16; // to be removed
     optional RTLevel realtime_level       = 17;
@@ -118,7 +117,6 @@ message JourneysRequest {
     required int32 max_transfers                        = 7;
     optional StreetNetworkParams streetnetwork_params   = 8;
     optional bool wheelchair                            = 9      [default=false];
-    optional bool show_codes                            = 11; // to be removed
     optional bool details                               = 13; //to be removed
     optional RTLevel realtime_level                     = 14;
     optional int32 max_extra_second_pass                = 15     [default=0];
@@ -177,7 +175,6 @@ message PTRefRequest {
     required int32 depth                = 3;
     required int32 start_page           = 4;
     required int32 count                = 5;
-    optional bool show_codes            = 7; // to be removed
     optional OdtLevel odt_level         = 8;
     repeated string forbidden_uri       = 6;
     optional uint64 datetime            = 9; // to be removed


### PR DESCRIPTION
After https://github.com/hove-io/kirin/pull/461
It's not used at all anymore (codes are always shown)

TODO:

- [ ] check that tests are OK on hove-io/navitia#3770