### PR TITLE
add optional distance in C02Emission request object

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -195,6 +195,7 @@ message PTRefRequest {
 message CarCO2EmissionRequest {
    optional LocationContext origin = 1;
    optional LocationContext destination = 2;
+   optional float distance = 3;
 }
 
 message DirectPathRequest {


### PR DESCRIPTION
Hi,

Second PR (I wanted to do it in the old one but it has been merged sorry).

I added the optional field in CO2Emission request object following @xlqian advice.

Thank you.