### PR TITLE
Revert "Pr co2 emission physical mode"

### DIFF
--- a/type.proto
+++ b/type.proto
@@ -316,7 +316,7 @@ message StopPoint {
     optional string label = 15;
     repeated CommercialMode commercial_modes = 17;
     repeated PhysicalMode physical_modes = 18;
-    optional FareZone fare_zone = 19;
+    optional FareZone fare_zone = 19;   
     repeated EquipmentDetails equipment_details = 20;
     repeated Line lines = 23;
     repeated AccessPoint access_points = 24;
@@ -570,7 +570,6 @@ message Network {
 message PhysicalMode {
     optional string uri = 3;
     optional string name = 4;
-    optional Co2EmissionRate co2_emission_rate = 5;
 }
 
 message CommercialMode {
@@ -674,13 +673,13 @@ message PtObject {
 }
 
 message FareZone {
-    optional string name = 1;
+    optional string name = 1;   
 }
 
 message EquipmentDetails {
     enum EquipmentType {
         escalator = 1;
-        elevator = 2;
+        elevator = 2;    
     }
     optional string id = 1;
     optional string name = 2;
@@ -731,7 +730,3 @@ message VehicleJourneyPosition {
     optional uint64 feed_created_at = 7;
 }
 
-message Co2EmissionRate {
-    optional double value = 1;
-    optional string unit = 2;
-}


### PR DESCRIPTION
Reverts hove-io/navitia-proto#186
This is not needed after changes made in https://github.com/hove-io/navitia/pull/3847