### PR TITLE
Add status.is_everything_loaded

### DIFF
--- a/response.proto
+++ b/response.proto
@@ -333,6 +333,8 @@ message Status{
     optional string dataset_created_at = 17;
     repeated string rt_contributors = 18;
     optional bool disruption_error = 19;
+
+    optional bool is_everything_loaded = 20;
 }
 
 message ScheduleStopTime {


### PR DESCRIPTION
Add a field `is_everything_loaded` to `status` response which is set to true if all the following are true: 

 -  the data.nav was successfully loaded
 - chaos database is configured AND chaos was successfully reloaded
 - is_realtime_enabled is configured to true AND kirin was successfully reloaded
 
See https://github.com/hove-io/navitia/pull/3860