### PR TITLE
Add air pollutants in the response

### DIFF
--- a/response.proto
+++ b/response.proto
@@ -138,6 +138,16 @@ message Co2Emission {
     optional string unit = 2;
 }
 
+message PollutantValues {
+    optional double nox = 1;
+    optional double pm10 = 2;
+}
+
+message AirPollutants {
+    optional PollutantValues values 1;
+    optional string unit 2;
+}
+
 message Durations {
     optional int32 total = 1;
     optional int32 walking = 2;
@@ -248,6 +258,7 @@ message Section {
     
     // via which Entrance/Exit
     repeated AccessPoint vias = 31;
+    optional AirPollutants air_pollutants 32;
 }
 
 message Journey {
@@ -278,6 +289,7 @@ message Journey {
     optional uint32 nb_sections = 20;
     optional Durations durations = 21;
     optional Distances distances = 22;
+    optional AirPollutants air_pollutants 23;
 }
 
 enum ResponseType {
@@ -618,6 +630,7 @@ message Response{
 
     // Terminus for all vehicle_journeys in journeys api
     repeated StopArea terminus = 78;
+    optional AirPollutants air_pollutants 79;
 }
 
 message NearestStopPoint{

--- a/response.proto
+++ b/response.proto
@@ -144,8 +144,8 @@ message PollutantValues {
 }
 
 message AirPollutants {
-    optional PollutantValues values 1;
-    optional string unit 2;
+    optional PollutantValues values = 1;
+    optional string unit = 2;
 }
 
 message Durations {
@@ -258,7 +258,7 @@ message Section {
     
     // via which Entrance/Exit
     repeated AccessPoint vias = 31;
-    optional AirPollutants air_pollutants 32;
+    optional AirPollutants air_pollutants = 32;
 }
 
 message Journey {
@@ -289,7 +289,7 @@ message Journey {
     optional uint32 nb_sections = 20;
     optional Durations durations = 21;
     optional Distances distances = 22;
-    optional AirPollutants air_pollutants 23;
+    optional AirPollutants air_pollutants = 23;
 }
 
 enum ResponseType {
@@ -630,7 +630,7 @@ message Response{
 
     // Terminus for all vehicle_journeys in journeys api
     repeated StopArea terminus = 78;
-    optional AirPollutants air_pollutants 79;
+    optional AirPollutants air_pollutants = 79;
 }
 
 message NearestStopPoint{


### PR DESCRIPTION
Add "air_pollutants" in section, journey and response for a journey using a car.
For details: https://navitia.atlassian.net/browse/NAV-1760

```
"co2_emission": {
        "value": 707.0814458325,
        "unit": "gEC"
      },
"air_pollutants": {
        "values": {
          "nox": 868.69,
          "pm10": 5876.8
        },
	"unit": "g"        
      },
```