### PR TITLE
Stop capacity criteria

### DIFF
--- a/request.proto
+++ b/request.proto
@@ -111,6 +111,8 @@ enum Criteria {
     Classic = 0;
     Robustness = 1;
     Occupancy = 2;
+    ArrivalStopCapacity = 3;
+    DepartureStopCapacity = 4;
 }
 
 message JourneysRequest {


### PR DESCRIPTION
Add two new criteria to be used in loki

- ArrivalStopCapacity : favors journeys that arrive at a stop with a high passenger capacity 
- DepartureStopCapacity : favors journeys that departs from a stop with a high passenger capacity 