### PR TITLE
Adding impact_uris in Poi

### DIFF
--- a/type.proto
+++ b/type.proto
@@ -578,6 +578,7 @@ message Poi {
     optional string label = 13;
     // for jormungandr only
     repeated Poi children = 14;
+    repeated string impact_uris = 15;
 }
 
 message Network {


### PR DESCRIPTION
This attribute is added to add links on impacts in a Poi.

Ticket: https://navitia.atlassian.net/browse/NAV-3026